### PR TITLE
feat: pass id to get media assets properly

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -440,7 +440,9 @@ class CollectionRowBlock(PageBlock):
         if prop["type"] in ["file"]:
             val = (
                 [
-                    add_signed_prefix_as_needed(item[1][0][1], client=self._client)
+                    add_signed_prefix_as_needed(
+                        item[1][0][1], client=self._client, id=self.id
+                    )
                     for item in val
                     if item[0] != ","
                 ]

--- a/notion/maps.py
+++ b/notion/maps.py
@@ -19,7 +19,7 @@ class mapper(property):
 def field_map(path, python_to_api=lambda x: x, api_to_python=lambda x: x):
     """
     Returns a property that maps a Block attribute onto a field in the API data structures.
-    
+
     - `path` can either be a top-level field-name, a list that specifies the key names to traverse,
       or a dot-delimited string representing the same traversal.
 
@@ -35,8 +35,12 @@ def field_map(path, python_to_api=lambda x: x, api_to_python=lambda x: x):
 
     def fget(self):
         kwargs = {}
-        if "client" in signature(api_to_python).parameters:
+        if (
+            "client" in signature(api_to_python).parameters
+            and "id" in signature(api_to_python).parameters
+        ):
             kwargs["client"] = self._client
+            kwargs["id"] = self.id
         return api_to_python(self.get(path), **kwargs)
 
     def fset(self, value):
@@ -74,13 +78,17 @@ def property_map(
             x = markdown_to_notion(x)
         return x
 
-    def api2py(x, client=None):
+    def api2py(x, client=None, id=""):
         x = x or [[""]]
         if markdown:
             x = notion_to_markdown(x)
         kwargs = {}
-        if "client" in signature(api_to_python).parameters:
+        if (
+            "client" in signature(api_to_python).parameters
+            and "id" in signature(api_to_python).parameters
+        ):
             kwargs["client"] = client
+            kwargs["id"] = id
         return api_to_python(x, **kwargs)
 
     return field_map(["properties", name], python_to_api=py2api, api_to_python=api2py)

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -60,13 +60,13 @@ def get_embed_link(source_url):
     return parse_qs(urlparse(url).query)["src"][0]
 
 
-def add_signed_prefix_as_needed(url, client=None):
+def add_signed_prefix_as_needed(url, client=None, id=""):
 
     if url is None:
         return
 
     if url.startswith(S3_URL_PREFIX):
-        url = SIGNED_URL_PREFIX + quote_plus(url)
+        url = SIGNED_URL_PREFIX + quote_plus(url) + "?table=block&id=" + id
         if client:
             url = client.session.head(url).headers.get("Location")
 


### PR DESCRIPTION
Notion has changed the API of getting image's source URL, as described in [this issue](https://github.com/jamalex/notion-py/issues/184).

[This PR](https://github.com/jamalex/notion-py/pull/185) (by @ruucm) resolve this issue.

So I applied it to my project
